### PR TITLE
fix: update the version of node from actions

### DIFF
--- a/.github/workflows/productions.yaml
+++ b/.github/workflows/productions.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: "18.16.0"
+          node-version: "16"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
BREAKING CHANGE:
Don't use lts version from NodeJS into GitHub Actions